### PR TITLE
Improved Logic for Article creation tests

### DIFF
--- a/cypress.env.json
+++ b/cypress.env.json
@@ -1,5 +1,6 @@
 {
       "APIusername": "jvargasatestcr",
       "APIemail": "jvargasatestcr@mailinator.com",
-      "APIpassword": "Super132!"
+      "APIpassword": "Super132!",
+      "ArticleSlug": "Automated-Title-156182"
 }

--- a/cypress/e2e/newArticle.cy.ts
+++ b/cypress/e2e/newArticle.cy.ts
@@ -40,6 +40,19 @@ describe('template spec', () => {
     cy.contains(feed.newArticleLink).click()
     cy.get('.btn').should('be.visible').should('contains.text',uiTexts.publishBtn)
   })
+
+  it ('Should not create a new Article when title is empty', () => {
+    //feed.clickOnNewArticle()
+    cy.contains(feed.newArticleLink).click()
+    cy.get(article.description).type(articleData.description)
+    cy.get(article.body).type(articleData.body)
+    cy.get(article.tags).type(articleData.tags)
+    cy.contains(article.button).click()
+    cy.get(article.titleErrorMsg).should('be.visible').should('contains.text',articleData.errorMsg)
+
+    
+  })
+
   it ('Should create a new Article', () => {
     //feed.clickOnNewArticle()
     cy.contains(feed.newArticleLink).click()
@@ -51,6 +64,11 @@ describe('template spec', () => {
     cy.get('h1.ng-binding').should('be.visible').should('contains.text',articleData.title)
 
     
+  })
+
+  after("delete Article", () => {
+    // Command to visit home page each time a test starts
+    cy.deleteCreatedArticle()
   })
 
 })

--- a/cypress/fixtures/article.json
+++ b/cypress/fixtures/article.json
@@ -2,5 +2,7 @@
     "title": "Automated Title",
     "description": "Automated Description",
     "body": "This is the body created using automation testing",
-    "tags": "QA, Automation, Testing"
+    "tags": "QA, Automation, Testing",
+    "slug": "automated-title",
+    "errorMsg": "title can't be blank"
 }

--- a/cypress/selectors/articlePage.sel.js
+++ b/cypress/selectors/articlePage.sel.js
@@ -4,7 +4,8 @@ module.exports = {
     description: ':nth-child(2) > .form-control',
     body: ':nth-child(3) > .form-control',
     tags: ':nth-child(4) > .form-control',
-    button: 'Publish Article'
+    button: 'Publish Article',
+    titleErrorMsg: 'div.ng-scope > .ng-binding'
     //Functions
     
 }

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -43,4 +43,16 @@ Cypress.Commands.add("userLogin", () => {
 }).then((response) => { 
     window.localStorage.setItem('jwtToken', response.body.user.token)
   })
+
+  Cypress.Commands.add("deleteCreatedArticle", () => {
+    //cy.userLogin()
+    cy.request({ 
+      method:"DELETE",
+      url: Cypress.env('apiUrl')+'/articles/'+Cypress.env('ArticleSlug'),
+      headers:{
+        'Authorization': 'Token '+window.localStorage.getItem('jwtToken')
+    },
+     
+    })
+  })
 })

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -23,7 +23,8 @@ declare global {
     namespace Cypress {
       interface Chainable {
         openHomePage(): Chainable<Element>
-        userLogin(): Chainable<Element>;
+        userLogin(): Chainable<Element>
+        deleteCreatedArticle(): Chainable<Element>
       }
     }
   }


### PR DESCRIPTION
I have added a new test case that verifies that leaving the empty title field does not create an article and shows the right error message. Also added logic to delete through API  the article created on the previous test case at the very end, so that way the test case will not fail/break on following runs