### PR TITLE
Added Cypress Dashboard Integration

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -1,6 +1,7 @@
 const { defineConfig } = require("cypress");
 
 module.exports = defineConfig({
+  projectId: "ghkhiq",
   env: {
     apiUrl: 'https://api.realworld.io/api'
 },

--- a/cypress/e2e/APITests/createUser.cy.ts
+++ b/cypress/e2e/APITests/createUser.cy.ts
@@ -9,7 +9,6 @@ describe("API Test Cases for user creation", () => {
       })
     
       it("Should create a new user",() =>{
-        cy.log(userData.user.email)
         cy.request({
             method:"POST",
             url: apiUrl+'/users',
@@ -18,9 +17,9 @@ describe("API Test Cases for user creation", () => {
             },
             body:{
                 "user":{
-                "username":userData.user.username,
-                "email": userData.user.email,
-                "password": userData.user.password
+                "username":userData.username,
+                "email": userData.email,
+                "password": userData.password
             }    
             }
         }).as('createUser')

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "devDependencies": {
     "cypress": "^12.8.1"
   },
+  "scripts": {
+    "run-dashboard": "npx cypress run --record --spec 'cypress/e2e/spec.cy.ts'"
+  },
   "dependencies": {
     "typescript": "^5.0.2"
   }


### PR DESCRIPTION
This PR allows the test run to be recorded on Cypress Cloud/Dashboard. Also fixes a pending fix from previous PR with the JSON structure for API Tests.
In order to run this locally you need to set your *CYPRESS_RECORD_KEY* as a system path variable according to your machine OS